### PR TITLE
Update "BargainLab" to Elm version 0.19

### DIFF
--- a/BargainLab.elm
+++ b/BargainLab.elm
@@ -1,6 +1,7 @@
 module BargainLab exposing (..)
 
 import Base64
+import Browser
 import Coalitions exposing (..)
 import Dict
 import GAMS
@@ -77,7 +78,7 @@ update msg model =
                     ( model, Random.generate Probs (Probabilities.probsDiagGen q.vars) )
 
                 Nothing ->
-                    Debug.crash ""
+                    Debug.todo ""
 
         Probs fs ->
             ( { model | probs = fs }, Cmd.none )
@@ -101,7 +102,7 @@ gameOptions =
 
 gameOption : Game -> Html Msg
 gameOption game =
-    option [ value (toString game) ] [ text (Games.showGame game) ]
+    option [ value (Debug.toString game) ] [ text (Games.showGame game) ]
 
 
 view : Model -> Html Msg
@@ -126,7 +127,7 @@ viewSize : Model -> Html Msg
 viewSize model =
     div []
         [ text "QOBDD nodes: "
-        , text (Maybe.withDefault "no size available" (Maybe.map (toString << QOBDD.size) model.qobdd))
+        , text (Maybe.withDefault "no size available" (Maybe.map (Debug.toString << QOBDD.size) model.qobdd))
         ]
 
 
@@ -134,14 +135,13 @@ viewCoalisions : Model -> Html Msg
 viewCoalisions model =
     div []
         [ text "Coalisions: "
-        , text (Maybe.withDefault "number of coalisions not available" (Maybe.map (toString << QOBDD.coalitions) model.qobdd))
+        , text (Maybe.withDefault "number of coalisions not available" (Maybe.map (Debug.toString << QOBDD.coalitions) model.qobdd))
         ]
 
 
 
 -- viewBanzhaf : Model -> Html Msg
 -- viewBanzhaf
-
 
 hrefDownload : String -> Attribute msg
 hrefDownload text =
@@ -157,7 +157,7 @@ viewFiles files =
         viewFile file =
             div []
                 [ a
-                    [ downloadAs file.name
+                    [ download file.name
                     , hrefDownload file.content
                     ]
                     [ text file.name ]
@@ -185,14 +185,14 @@ viewProbs probs =
 viewProbsRow : Int -> List Float -> Html a
 viewProbsRow i probs =
     div []
-        (text ("Player " ++ toString i ++ ": ")
+        (text ("Player " ++ Debug.toString i ++ ": ")
             :: [ text (String.concat (List.intersperse ", " (List.map viewProb probs))) ]
         )
 
 
 viewProb : Float -> String
 viewProb f =
-    toString f
+    Debug.toString f
 
 
 viewPowerList : Model -> Html Msg
@@ -205,7 +205,7 @@ viewPowerListQOBDD : QOBDD -> List (List Float) -> Html Msg
 viewPowerListQOBDD qobdd probs =
     let
         probDicts =
-            List.map (\ps -> Dict.fromList (List.indexedMap (\i p -> ( i, p )) ps)) probs
+            List.map (\ps2 -> Dict.fromList (List.indexedMap (\i p -> ( i, p )) ps2)) probs
 
         ps =
             Probabilities.probs probDicts qobdd
@@ -215,12 +215,12 @@ viewPowerListQOBDD qobdd probs =
 
 viewPower : Int -> Float -> Html Msg
 viewPower player prob =
-    div [] [ text ("Power of player " ++ toString player ++ ": " ++ toString prob) ]
+    div [] [ text ("Power of player " ++ Debug.toString player ++ ": " ++ Debug.toString prob) ]
 
 
 viewResult : Maybe QOBDD -> (BDD -> a) -> Html Msg
 viewResult mqobdd f =
-    div [] [ text (Maybe.withDefault "no result" (Maybe.map (toString << f << .bdd) mqobdd)) ]
+    div [] [ text (Maybe.withDefault "no result" (Maybe.map (Debug.toString << f << .bdd) mqobdd)) ]
 
 
 subscriptions : Model -> Sub Msg
@@ -228,10 +228,10 @@ subscriptions model =
     parsedMWVG Parsed
 
 
-main : Program Never Model Msg
+main : Program Bool Model Msg
 main =
-    program
-        { init = init
+    Browser.element
+        { init = \_ -> init
         , view = view
         , update = update
         , subscriptions = subscriptions

--- a/BargainLab.elm
+++ b/BargainLab.elm
@@ -228,7 +228,7 @@ subscriptions model =
     parsedMWVG Parsed
 
 
-main : Program Bool Model Msg
+main : Program () Model Msg
 main =
     Browser.element
         { init = \_ -> init


### PR DESCRIPTION
Change the "main" function type, since the type "Never" 
is not accepted anymore.

The first argument in the record used in the "main" function 
must take flags, but since they werent used before discard them
with a lambda expression

"programm" is replaced with Browser.element, since
Browser.document needs a different return type in the "view"
function. This wouldnt be a big deal to change,
however i dont see the necessity for more controll 
over the title and body.

Addresses: #1, #5
Fixes: #6 
